### PR TITLE
docs: remove section on confirming that it is a list

### DIFF
--- a/sessions/functionals.qmd
+++ b/sessions/functionals.qmd
@@ -724,15 +724,6 @@ list(average = mean)
 list(ave = mean)
 ```
 
-You can confirm that it is a list by using the function `names()`:
-
-```{r}
-#| filename: "Console"
-names(list(mean = mean))
-names(list(average = mean))
-names(list(ave = mean))
-```
-
 Let's stick with `list(mean = mean)`:
 
 ```{r}


### PR DESCRIPTION
## Description 

Not sure if this is controversial, but it's not clear to me why this check is needed here. I think the example above with adding different names is enough - and this session is quite long already :)